### PR TITLE
Implement Sink for Sender<T>

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -19,11 +19,11 @@ jobs:
       
       - name: Set current week of the year in environnement
         if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macOS')
-        run: echo "::set-env name=CURRENT_WEEK::$(date +%V)"
+        run: echo "CURRENT_WEEK=$(date +%V)" >> $GITHUB_ENV
       
       - name: Set current week of the year in environnement
         if: startsWith(matrix.os, 'windows')
-        run: echo "::set-env name=CURRENT_WEEK::$(Get-Date -UFormat %V)"
+        run: echo "::set-env name=CURRENT_WEEK::$(date +%V)"
 
       - name: Install latest ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       
       - name: Set current week of the year in environnement
-        run: echo "::set-env name=CURRENT_WEEK::$(date +%V)"
+        run: echo "CURRENT_WEEK=$(date +%V)" >> $GITHUB_ENV
       
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       
       - name: Set current week of the year in environnement
-        run: echo "::set-env name=CURRENT_WEEK::$(date +%V)"
+        run: echo "CURRENT_WEEK=$(date +%V)" >> $GITHUB_ENV
       
       - uses: actions-rs/audit-check@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ readme = "README.md"
 
 [dependencies]
 concurrent-queue = "1.2.2"
-event-listener = "2.4.0"
-futures-core = "0.3.5"
+event-listener = "2.5.1"
+futures-core = "0.3.8"
 
 [dev-dependencies]
 blocking = "0.6.0"
 easy-parallel = "3.1.0"
-futures-lite = "1.11.0"
+futures-lite = "1.11.2"

--- a/tests/unbounded.rs
+++ b/tests/unbounded.rs
@@ -298,3 +298,108 @@ fn mpmc_stream() {
         assert_eq!(c.load(Ordering::SeqCst), THREADS);
     }
 }
+
+#[test]
+fn poll_send() {
+    let (mut s, r) = unbounded();
+
+    Parallel::new()
+        .add(|| {
+            future::block_on(async {
+                future::poll_fn(|cx| s.poll_send(cx, &mut Some(7u32)))
+                    .await
+                    .unwrap();
+            });
+            sleep(ms(1000));
+            future::block_on(async {
+                future::poll_fn(|cx| s.poll_send(cx, &mut Some(8u32)))
+                    .await
+                    .unwrap();
+            });
+            sleep(ms(1000));
+            future::block_on(async {
+                future::poll_fn(|cx| s.poll_send(cx, &mut Some(9u32)))
+                    .await
+                    .unwrap();
+            });
+            sleep(ms(1000));
+            future::block_on(async {
+                future::poll_fn(|cx| s.poll_send(cx, &mut Some(10u32)))
+                    .await
+                    .unwrap();
+            });
+        })
+        .add(|| {
+            sleep(ms(1500));
+            assert_eq!(future::block_on(r.recv()), Ok(7));
+            assert_eq!(future::block_on(r.recv()), Ok(8));
+            assert_eq!(future::block_on(r.recv()), Ok(9));
+        })
+        .run();
+}
+
+#[test]
+fn spsc_poll_send() {
+    const COUNT: usize = 25_000;
+
+    let (s, r) = unbounded();
+
+    Parallel::new()
+        .add({
+            let mut r = r.clone();
+            move || {
+                for _ in 0..COUNT {
+                    future::block_on(r.next()).unwrap();
+                }
+            }
+        })
+        .add(|| {
+            let s = s.clone();
+            for i in 0..COUNT {
+                let mut s = s.clone();
+                future::block_on(async {
+                    future::poll_fn(|cx| s.poll_send(cx, &mut Some(i)))
+                        .await
+                        .unwrap();
+                });
+            }
+        })
+        .run();
+}
+
+#[test]
+fn mpmc_poll_send() {
+    const COUNT: usize = 25_000;
+    const THREADS: usize = 4;
+
+    let (s, r) = unbounded::<usize>();
+    let v = (0..COUNT).map(|_| AtomicUsize::new(0)).collect::<Vec<_>>();
+    let v = &v;
+
+    Parallel::new()
+        .each(0..THREADS, {
+            let mut r = r.clone();
+            move |_| {
+                for _ in 0..COUNT {
+                    let n = future::block_on(r.next()).unwrap();
+                    v[n].fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        })
+        .each(0..THREADS, |_| {
+            let s = s.clone();
+            for i in 0..COUNT {
+                let mut s = s.clone();
+                future::block_on(async {
+                    future::poll_fn(|cx| s.poll_send(cx, &mut Some(i)))
+                        .await
+                        .unwrap();
+                });
+            }
+        })
+        .run();
+
+    for c in v {
+        assert_eq!(c.load(Ordering::SeqCst), THREADS);
+    }
+}


### PR DESCRIPTION
I've read the discussion in #12, and I'm trying to implement Sink for Sender.

Crate [futures-sink](https://crates.io/crates/futures-sink) was added to `dependencies`, which only includes the trait.

Hope it would help :)