### PR TITLE
Add `Send` and `Recv` futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["asynchronous", "concurrency"]
 concurrent-queue = "1.2.2"
 event-listener = "2.4.0"
 futures-core = "0.3.5"
+pin-project-lite = "0.2.4"
 
 [dev-dependencies]
 blocking = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["asynchronous", "concurrency"]
 concurrent-queue = "1.2.2"
 event-listener = "2.4.0"
 futures-core = "0.3.5"
-pin-project-lite = "0.2.4"
 
 [dev-dependencies]
 blocking = "1"


### PR DESCRIPTION
Closes https://github.com/smol-rs/async-channel/issues/22. cc/ @taiki-e I'm pretty sure the `pin-project-lite` impls here aren't needed, but my brain is too mush to think of how to do it using the pin-utils variants. Thanks!