### PR TITLE
Fix documentation sentence

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,7 +450,7 @@ pub struct Receiver<T> {
 impl<T> Receiver<T> {
     /// Attempts to receive a message from the channel.
     ///
-    /// If the channel is empty or closed, this method returns an error.
+    /// If the channel is empty, or empty and closed, this method returns an error.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
In https://docs.rs/concurrent-queue/1.2.2/concurrent_queue/enum.PopError.html states that PopError::Closed only applies when it is empty **and** closed. 

Ideally, the documentation phrase should be "If the channel is empty, this method returns an error." because "empty, or empty and closed" can be reduced to "empty" but in order to specify both error types, I left it as "empty, or empty and closed".

This took some hours for me to check if the library was doing what I was expecting it to do. I hope this change saves this time to future readers of the documentation.