### PR TITLE
Add blocking functionality to channels

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,9 +254,8 @@ impl<T> Sender<T> {
     ///
     /// This method should not be used in an asynchronous context. It is intended
     /// to be used such that a channel can be used in both asynchronous and synchronous contexts.
-    /// Calling this method in an `async` block will result in undefined behavior,
-    /// including deadlocks.
-    ///
+    /// Calling this method in an `async` block may result in deadlocks.
+    ///  
     /// # Examples
     ///
     /// ```
@@ -554,8 +553,7 @@ impl<T> Receiver<T> {
     ///
     /// This method should not be used in an asynchronous context. It is intended
     /// to be used such that a channel can be used in both asynchronous and synchronous contexts.
-    /// Calling this method in an `async` block will result in undefined behavior,
-    /// including deadlocks.
+    /// Calling this method in an `async` block may result in deadlocks.
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ impl<T> Sender<T> {
     ///
     /// This method should not be used in an asynchronous context. It is intended
     /// to be used such that a channel can be used in both asynchronous and synchronous contexts.
-    /// Calling this method in an `async` block may result in deadlocks.
+    /// Calling this method in an asynchronous context may result in deadlocks.
     ///  
     /// # Examples
     ///

--- a/tests/bounded.rs
+++ b/tests/bounded.rs
@@ -24,6 +24,22 @@ fn smoke() {
 }
 
 #[test]
+fn smoke_blocking() {
+    let (s, r) = bounded(1);
+
+    s.send_blocking(7).unwrap();
+    assert_eq!(r.try_recv(), Ok(7));
+
+    s.send_blocking(8).unwrap();
+    assert_eq!(future::block_on(r.recv()), Ok(8));
+
+    future::block_on(s.send(9)).unwrap();
+    assert_eq!(r.recv_blocking(), Ok(9));
+
+    assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
+}
+
+#[test]
 fn capacity() {
     for i in 1..10 {
         let (s, r) = bounded::<()>(i);

--- a/tests/unbounded.rs
+++ b/tests/unbounded.rs
@@ -23,6 +23,22 @@ fn smoke() {
 }
 
 #[test]
+fn smoke_blocking() {
+    let (s, r) = unbounded();
+
+    s.send_blocking(7).unwrap();
+    assert_eq!(r.try_recv(), Ok(7));
+
+    s.send_blocking(8).unwrap();
+    assert_eq!(future::block_on(r.recv()), Ok(8));
+
+    future::block_on(s.send(9)).unwrap();
+    assert_eq!(r.recv_blocking(), Ok(9));
+
+    assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
+}
+
+#[test]
 fn capacity() {
     let (s, r) = unbounded::<()>();
     assert_eq!(s.capacity(), None);


### PR DESCRIPTION
As per discussion in smol-rs/async-lock#25, I have added `send_blocking` and `recv_blocking` methods to the `Sender` and `Receiver` structures, respectively. In order to reduce code duplication, I implemented this by parameterizing the logic found in the `Send` and `Recv` futures using a trait that either `poll`s the `EventListener` or calls `wait` on it.

Various things I left up in the air:

- I added private `wait()` methods on `Send` and `Recv` that use the blocking strategy to poll the future to completion. Should these be public?
- `Recv` currently implements `Stream`. It could also implement `Iterator` using a similar strategy to how I implemented blocking for the main methods. I decided against it, since `StreamExt` and `Iterator` share many method names which could be confused. Is there an idiomatic way of going about this?
- Do I need more tests? Since I piggyback off of the previous logic I didn't think so, but I'm not sure what the general policy is.

Closes #21