### PR TITLE
Prevent deadlock if sender/receiver is forgotten

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ futures-core = "0.3.5"
 [dev-dependencies]
 easy-parallel = "3"
 futures-lite = "1"
+waker-fn = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,3 @@ futures-core = "0.3.5"
 [dev-dependencies]
 easy-parallel = "3"
 futures-lite = "1"
-waker-fn = "1"


### PR DESCRIPTION
Fixes https://github.com/smol-rs/async-channel/issues/45.

This is mostly similar to PR https://github.com/smol-rs/async-channel/pull/16 by another author, but its motivation is correctness rather than the purported performance advantage. Differences with PR https://github.com/smol-rs/async-channel/pull/16:
- it adds correctness tests for the case of forgotten sender and forgotten receiver,
- the commit is based on 1.7.0,
- the listener is not discarded when the future completes: in my understanding this would only help in the rare case where a sender/receiver completes due to a spurious wake-up (without consuming its notification); if my understanding is correct, I would say that the fixed cost of the extra conditional does not carry its weight.

I have made some benchmarking in various scenarios and did not observe a meaningful difference in terms of performance.

That being said, we can't exclude that performance could be degraded in extreme cases. In theory degraded performance could happen with a very large number of fast senders combined with a fast receiver loop: a receiver which rapidly empties the channel would generate many notifications but if the first sender consume all the capacity before the remaining senders are polled, most notifications would be wasted. A symmetric situation could occur with many receivers and a fast sender loop.