### PR TITLE
Add weak sender and receiver

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -825,7 +825,7 @@ impl<T> futures_core::stream::FusedStream for Receiver<T> {
 }
 
 /// A [`Sender`] that prevents the channel from not being closed.
-/// 
+///
 /// This is created through the [`Sender::downgrade`] method. In order to use it, it needs
 /// to be upgraded into a [`Sender`] through the `upgrade` method.
 #[derive(Clone)]
@@ -839,7 +839,7 @@ impl<T> WeakSender<T> {
         if self.channel.queue.is_closed() {
             None
         } else {
-            let old_count = self.channel.sender_count.fetch_add(1, Ordering::Relaxed); 
+            let old_count = self.channel.sender_count.fetch_add(1, Ordering::Relaxed);
             if old_count == 0 {
                 // Channel was closed while we were incrementing the count.
                 self.channel.sender_count.store(0, Ordering::Release);
@@ -863,7 +863,7 @@ impl<T> fmt::Debug for WeakSender<T> {
 }
 
 /// A [`Receiver`] that prevents the channel from not being closed.
-/// 
+///
 /// This is created through the [`Receiver::downgrade`] method. In order to use it, it needs
 /// to be upgraded into a [`Receiver`] through the `upgrade` method.
 #[derive(Clone)]
@@ -877,7 +877,7 @@ impl<T> WeakReceiver<T> {
         if self.channel.queue.is_closed() {
             None
         } else {
-            let old_count = self.channel.receiver_count.fetch_add(1, Ordering::Relaxed); 
+            let old_count = self.channel.receiver_count.fetch_add(1, Ordering::Relaxed);
             if old_count == 0 {
                 // Channel was closed while we were incrementing the count.
                 self.channel.receiver_count.store(0, Ordering::Release);

--- a/tests/bounded.rs
+++ b/tests/bounded.rs
@@ -455,3 +455,28 @@ fn mpmc_stream() {
         assert_eq!(c.load(Ordering::SeqCst), THREADS);
     }
 }
+
+#[test]
+fn weak() {
+    let (s, r) = bounded::<usize>(3);
+
+    // Create a weak sender/receiver pair.
+    let (weak_s, weak_r) = (s.downgrade(), r.downgrade());
+
+    // Upgrade and send.
+    {
+        let s = weak_s.upgrade().unwrap();
+        s.send_blocking(3).unwrap();
+        let r = weak_r.upgrade().unwrap();
+        assert_eq!(r.recv_blocking(), Ok(3));
+    }
+
+    // Drop the original sender/receiver pair.
+    drop((s, r));
+
+    // Try to upgrade again.
+    {
+        assert!(weak_s.upgrade().is_none());
+        assert!(weak_r.upgrade().is_none());
+    }
+}


### PR DESCRIPTION
`tokio` recently added weak senders to its MPSC channel, and I thought that it was a pretty good idea. This PR adds a weak sender and receiver to this crate.