### PR TITLE
Update to e-l-s breaking changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ wasm-bindgen-test = "0.3.37"
 [features]
 default = ["std"]
 std = ["concurrent-queue/std", "event-listener/std", "event-listener-strategy/std"]
+
+[patch.crates-io]
+event-listener-strategy = { git = "https://github.com/smol-rs/event-listener-strategy", branch = "notgull/no-lt" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1103,7 +1103,7 @@ impl<'a, T> EventListenerFuture for SendInner<'a, T> {
 
     /// Run this future with the given `Strategy`.
     fn poll_with_strategy<'x, S: Strategy<'x>>(
-        self: Pin<&'x mut Self>,
+        self: Pin<&mut Self>,
         strategy: &mut S,
         context: &mut S::Context,
     ) -> Poll<Result<(), SendError<T>>> {
@@ -1152,7 +1152,7 @@ impl<'a, T> EventListenerFuture for RecvInner<'a, T> {
 
     /// Run this future with the given `Strategy`.
     fn poll_with_strategy<'x, S: Strategy<'x>>(
-        self: Pin<&'x mut Self>,
+        self: Pin<&mut Self>,
         strategy: &mut S,
         cx: &mut S::Context,
     ) -> Poll<Result<T, RecvError>> {


### PR DESCRIPTION
Make sure that smol-rs/event-listener-strategy#6 doesn't break the other main use case.