### PR TITLE
v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 2.1.1
+
+- Bump `event-listener` to v4.0.0. (#73)
+
 # Version 2.1.0
 
 - Bump `futures-lite` to its latest version. (#70)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-channel"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.59"


### PR DESCRIPTION
- Bump `event-listener` to v4.0.0. (#73)
