### PR TITLE
v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2.2.0
+
+- Bump `event-listener` to v5.0.0. (#79)
+- Bump MSRV to 1.60. (#80)
+
 # Version 2.1.1
 
 - Bump `event-listener` to v4.0.0. (#73)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-channel"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.1.1"
+version = "2.2.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
- Bump `event-listener` to v5.0.0. (#79)
- Bump MSRV to 1.60. (#80)
