### PR TITLE
Use the reexported event-listener from event-listener-strategy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ exclude = ["/.*"]
 
 [dependencies]
 concurrent-queue = { version = "2", default-features = false }
-event-listener = { version = "5.0.0", default-features = false }
-event-listener-strategy = { version = "0.5.0", default-features = false }
+event-listener-strategy = { version = "0.5.2", default-features = false }
 futures-core = { version = "0.3.5", default-features = false }
 pin-project-lite = "0.2.11"
 
@@ -30,4 +29,4 @@ wasm-bindgen-test = "0.3.37"
 
 [features]
 default = ["std"]
-std = ["concurrent-queue/std", "event-listener/std", "event-listener-strategy/std"]
+std = ["concurrent-queue/std", "event-listener-strategy/std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,11 @@ use core::task::{Context, Poll};
 use alloc::sync::Arc;
 
 use concurrent_queue::{ConcurrentQueue, ForcePushError, PopError, PushError};
-use event_listener::{Event, EventListener};
-use event_listener_strategy::{easy_wrapper, EventListenerFuture, Strategy};
+use event_listener_strategy::{
+    easy_wrapper,
+    event_listener::{Event, EventListener},
+    EventListenerFuture, Strategy,
+};
 use futures_core::ready;
 use futures_core::stream::Stream;
 use pin_project_lite::pin_project;


### PR DESCRIPTION
Avoid needing to keep both event-listener and event-listener-strategy in sync by just relying on the reexport from event-listener-strategy. Should be a non-breaking change, since all of these changes should be semver compatible.