### PR TITLE
v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 2.3.1
+
+- Use the correct version of `async-channel` in our manifest. (#93)
+
 # Version 2.3.0
 
 - Add `force_send` for sending items over the channel that displace other items. (#89)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-channel"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
- Use the correct version of `async-channel` in our manifest. (#93)
