### PR TITLE
Add a fn to check if two senders or two receivers use the same channel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,6 +493,11 @@ impl<T> Sender<T> {
             channel: self.channel.clone(),
         }
     }
+
+    /// Returns whether the senders belong to the same channel.
+    pub fn same_channel(&self, other: &Sender<T>) -> bool {
+        Arc::ptr_eq(&self.channel, &other.channel)
+    }
 }
 
 impl<T> Drop for Sender<T> {
@@ -819,6 +824,11 @@ impl<T> Receiver<T> {
         WeakReceiver {
             channel: self.channel.clone(),
         }
+    }
+
+    /// Returns whether the receivers belong to the same channel.
+    pub fn same_channel(&self, other: &Receiver<T>) -> bool {
+        Arc::ptr_eq(&self.channel, &other.channel)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,6 +495,19 @@ impl<T> Sender<T> {
     }
 
     /// Returns whether the senders belong to the same channel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures_lite::future::block_on(async {
+    /// use async_channel::unbounded;
+    ///
+    /// let (s, r) = unbounded::<()>();
+    /// let s2 = s.clone();
+    ///
+    /// assert!(s.same_channel(&s2));
+    /// # });
+    /// ```
     pub fn same_channel(&self, other: &Sender<T>) -> bool {
         Arc::ptr_eq(&self.channel, &other.channel)
     }
@@ -827,6 +840,19 @@ impl<T> Receiver<T> {
     }
 
     /// Returns whether the receivers belong to the same channel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures_lite::future::block_on(async {
+    /// use async_channel::unbounded;
+    ///
+    /// let (s, r) = unbounded::<()>();
+    /// let r2 = r.clone();
+    ///
+    /// assert!(r.same_channel(&r2));
+    /// # });
+    /// ```
     pub fn same_channel(&self, other: &Receiver<T>) -> bool {
         Arc::ptr_eq(&self.channel, &other.channel)
     }


### PR DESCRIPTION
I am porting some code from flume to async_channel, and this is one fn that I am sorely missing.

The implementation seems to be quite simple.