### PR TITLE
Add Sender::closed future

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ impl<T> Sender<T> {
     /// # futures_lite::future::block_on(async {
     /// use async_channel::{unbounded, SendError};
     ///
-    /// let (s, r) = unbounded();
+    /// let (s, r) = unbounded::<i32>();
     /// drop(r);
     /// s.closed().await;
     /// # });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1353,7 +1353,7 @@ impl<'a, T> EventListenerFuture for ClosedInner<'a, T> {
             // Poll using the given strategy
             ready!(S::poll(strategy, &mut *this.listener, cx));
         }
-        return Poll::Ready(());
+        Poll::Ready(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1310,7 +1310,7 @@ impl<'a, T> EventListenerFuture for RecvInner<'a, T> {
 }
 
 easy_wrapper! {
-    /// A future returned by [`Receiver::recv()`].
+    /// A future returned by [`Sender::closed()`].
     #[derive(Debug)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct Closed<'a, T>(ClosedInner<'a, T> => ());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,6 +277,7 @@ impl<T> Sender<T> {
     /// let (s, r) = unbounded();
     /// drop(r);
     /// s.closed().await;
+    /// # });
     /// ```
     pub fn closed(&self) -> Closed<'_, T> {
         Closed::_new(ClosedInner {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ impl<T> Sender<T> {
         })
     }
 
-    /// Completes when all receiver have dropped.
+    /// Completes when all receivers have dropped.
     ///
     /// This allows the producers to get notified when interest in the produced values is canceled and immediately stop doing work.
     ///


### PR DESCRIPTION
This adds `Sender::closed()` similar to `tokio::sync::mpsc::Sender::closed()` ([link](https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.Sender.html#method.closed)).