### PR TITLE
ci: Use reusable workflows for fmt and security_audit & fix CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,16 @@ defaults:
     shell: bash
 
 jobs:
+  fmt:
+    uses: smol-rs/.github/.github/workflows/fmt.yml@main
+  security_audit:
+    uses: smol-rs/.github/.github/workflows/security_audit.yml@main
+    permissions:
+      checks: write
+      contents: read
+      issues: write
+    secrets: inherit
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -74,27 +84,3 @@ jobs:
       - name: Install Rust
         run: rustup update stable
       - run: cargo clippy --all-features --all-targets
-
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup update stable
-      - run: cargo fmt --all --check
-
-  security_audit:
-    permissions:
-      checks: write
-      contents: read
-      issues: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      # rustsec/audit-check used to do this automatically
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
-      # https://github.com/rustsec/audit-check/issues/2
-      - uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1194,7 +1194,7 @@ pin_project! {
     }
 }
 
-impl<'a, T> EventListenerFuture for SendInner<'a, T> {
+impl<T> EventListenerFuture for SendInner<'_, T> {
     type Output = Result<(), SendError<T>>;
 
     /// Run this future with the given `Strategy`.
@@ -1250,7 +1250,7 @@ pin_project! {
     }
 }
 
-impl<'a, T> EventListenerFuture for RecvInner<'a, T> {
+impl<T> EventListenerFuture for RecvInner<'_, T> {
     type Output = Result<T, RecvError>;
 
     /// Run this future with the given `Strategy`.


### PR DESCRIPTION
See the first commit and https://github.com/smol-rs/.github/pull/1 for reusable workflows.
And see the second commit for CI failure.