### PR TITLE
Support portable atomic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: "0 2 * * 0"
+    - cron: '0 2 * * 0'
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: '0 2 * * 0'
+    - cron: "0 2 * * 0"
 
 env:
   CARGO_INCREMENTAL: 0
@@ -54,14 +54,16 @@ jobs:
         run: cargo check -Z features=dev_dep
       - run: cargo test
       - run: cargo test --no-default-features
+      - run: cargo test --feature portable-atomic
+      - run: cargo test --no-default-features --feature portable-atomic
       - name: Install cargo-hack and wasm-pack
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack,cargo-minimal-versions,wasm-pack
       - run: rustup target add thumbv7m-none-eabi
       - name: Run cargo check (without dev-dependencies to catch missing feature flags)
-        run: cargo hack build --all --no-dev-deps
-      - run: cargo hack build --all --target thumbv7m-none-eabi --no-default-features --no-dev-deps
+      - run: cargo hack build --feature-powerset --no-dev-deps
+      - run: cargo hack build --feature-powerset --no-dev-deps --target thumbv7m-none-eabi --skip std,default
       - name: Run cargo check for WASM
         run: cargo check --all --all-features --all-targets --target wasm32-unknown-unknown
       - name: Test WASM
@@ -74,8 +76,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
-      - run: cargo hack build --rust-version
-      - run: cargo hack build --no-default-features --rust-version
+      - run: cargo hack build --feature-powerset --no-dev-deps --rust-version
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack,cargo-minimal-versions,wasm-pack
-      - run: rustup target add thumbv7m-none-eabi
+      - run: rustup target add thumbv6m-none-eabi thumbv7m-none-eabi
       - name: Run cargo check (without dev-dependencies to catch missing feature flags)
         run: cargo hack build --feature-powerset --no-dev-deps
       - name: Run cargo check for non atomic platforms

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,10 @@ jobs:
       - run: rustup target add thumbv6m-none-eabi thumbv7m-none-eabi
       - name: Run cargo check (without dev-dependencies to catch missing feature flags)
         run: cargo hack build --feature-powerset --no-dev-deps
-      - name: Run cargo check for non atomic platforms
+      - name: Run cargo check for no-std target with atomic CAS
         run: cargo hack build --feature-powerset --no-dev-deps --target thumbv7m-none-eabi --skip std,default
+      - name: Run cargo check for no-std target without atomic CAS
+        run: cargo hack build --feature-powerset --no-dev-deps --target thumbv6m-none-eabi --skip std,default --features portable-atomic,portable-atomic/critical-section
       - name: Run cargo check for WASM
         run: cargo check --all --all-features --all-targets --target wasm32-unknown-unknown
       - name: Test WASM

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,16 +54,17 @@ jobs:
         run: cargo check -Z features=dev_dep
       - run: cargo test
       - run: cargo test --no-default-features
-      - run: cargo test --feature portable-atomic
-      - run: cargo test --no-default-features --feature portable-atomic
+      - run: cargo test --features portable-atomic
+      - run: cargo test --no-default-features --features portable-atomic
       - name: Install cargo-hack and wasm-pack
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack,cargo-minimal-versions,wasm-pack
       - run: rustup target add thumbv7m-none-eabi
       - name: Run cargo check (without dev-dependencies to catch missing feature flags)
-      - run: cargo hack build --feature-powerset --no-dev-deps
-      - run: cargo hack build --feature-powerset --no-dev-deps --target thumbv7m-none-eabi --skip std,default
+        run: cargo hack build --feature-powerset --no-dev-deps
+      - name: Run cargo check for non atomic platforms
+        run: cargo hack build --feature-powerset --no-dev-deps --target thumbv7m-none-eabi --skip std,default
       - name: Run cargo check for WASM
         run: cargo check --all --all-features --all-targets --target wasm32-unknown-unknown
       - name: Test WASM

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ event-listener-strategy = { version = "0.5.2", default-features = false }
 futures-core = { version = "0.3.5", default-features = false }
 pin-project-lite = "0.2.11"
 
+# This dependency is unused, but it lets us add features to it.
+__event-listener = { version = "5", default-features = false, package = "event-listener" }
+
 [dev-dependencies]
 easy-parallel = "3"
 futures-lite = "2"
@@ -30,3 +33,4 @@ wasm-bindgen-test = "0.3.37"
 [features]
 default = ["std"]
 std = ["concurrent-queue/std", "event-listener-strategy/std"]
+portable-atomic = ["concurrent-queue/portable-atomic", "__event-listener/portable-atomic"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ pin-project-lite = "0.2.11"
 # This dependency is unused, but it lets us add features to it.
 __event-listener = { version = "5", default-features = false, package = "event-listener" }
 
-portable-atomic = { version = "1", default-features = false, features = ["require-cas", "fallback", "critical-section"], optional = true }
+portable-atomic = { version = "1", default-features = false, features = ["require-cas"], optional = true }
 portable-atomic-util = { version = "0.2", default-features = false, features = ["alloc"], optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,9 @@ exclude = ["/.*"]
 
 [dependencies]
 concurrent-queue = { version = "2.5", default-features = false }
-event-listener-strategy = { version = "0.5.2", default-features = false }
+event-listener-strategy = { version = "0.5.4", default-features = false }
 futures-core = { version = "0.3.5", default-features = false }
 pin-project-lite = "0.2.11"
-
-# This dependency is unused, but it lets us add features to it.
-__event-listener = { version = "5", default-features = false, package = "event-listener" }
 
 portable-atomic = { version = "1", default-features = false, features = ["require-cas"], optional = true }
 portable-atomic-util = { version = "0.2", default-features = false, features = ["alloc"], optional = true }
@@ -36,4 +33,4 @@ wasm-bindgen-test = "0.3.37"
 [features]
 default = ["std"]
 std = ["concurrent-queue/std", "event-listener-strategy/std"]
-portable-atomic = ["concurrent-queue/portable-atomic", "__event-listener/portable-atomic", "dep:portable-atomic-util", "dep:portable-atomic"]
+portable-atomic = ["concurrent-queue/portable-atomic", "event-listener-strategy/portable-atomic", "dep:portable-atomic-util", "dep:portable-atomic"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ pin-project-lite = "0.2.11"
 # This dependency is unused, but it lets us add features to it.
 __event-listener = { version = "5", default-features = false, package = "event-listener" }
 
+portable-atomic = { version = "1", default-features = false, features = ["require-cas", "fallback", "critical-section"], optional = true }
+portable-atomic-util = { version = "0.2", default-features = false, features = ["alloc"], optional = true }
+
 [dev-dependencies]
 easy-parallel = "3"
 futures-lite = "2"
@@ -33,4 +36,4 @@ wasm-bindgen-test = "0.3.37"
 [features]
 default = ["std"]
 std = ["concurrent-queue/std", "event-listener-strategy/std"]
-portable-atomic = ["concurrent-queue/portable-atomic", "__event-listener/portable-atomic"]
+portable-atomic = ["concurrent-queue/portable-atomic", "__event-listener/portable-atomic", "dep:portable-atomic-util", "dep:portable-atomic"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,16 +36,24 @@
     html_logo_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
 )]
 
+#[cfg(not(feature = "portable-atomic"))]
 extern crate alloc;
 
 use core::fmt;
 use core::future::Future;
 use core::marker::PhantomPinned;
 use core::pin::Pin;
-use core::sync::atomic::{AtomicUsize, Ordering};
 use core::task::{Context, Poll};
 
+#[cfg(not(feature = "portable-atomic"))]
 use alloc::sync::Arc;
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic::{AtomicUsize, Ordering};
+#[cfg(feature = "portable-atomic")]
+use portable_atomic_util::Arc;
 
 use concurrent_queue::{ConcurrentQueue, ForcePushError, PopError, PushError};
 use event_listener_strategy::{


### PR DESCRIPTION
This lets users use this crate on targets that don't support atomics.

`cargo check --no-default-features --target thumbv6m-none-eabi` Fails on main.

But `cargo check --no-default-features --target thumbv6m-none-eabi --features portable-atomic,portable-atomic/fallback,portable-atomic/critical-section` passes on this PR.

This is blocking work in dependent PRs, for example, see [here](https://github.com/bevyengine/bevy/actions/runs/14090648644/job/39466542651?pr=18525).