### PR TITLE
Release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2.4.0
+
+- Add `Sender::same_channel()` and `Receiver::same_channel()`. (#98)
+- Add `portable-atomic` feature to support platforms without atomics. (#106)
+
 # Version 2.3.1
 
 - Use the correct version of `async-channel` in our manifest. (#93)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-channel"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
Changes:
- Add `Sender::same_channel()` and `Receiver::same_channel()`. (#98)
- Add `portable-atomic` feature to support platforms without atomics. (#106)