### PR TITLE
Allow deprecated lint on fetch_update

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -983,6 +983,7 @@ impl<T> WeakSender<T> {
         if self.channel.queue.is_closed() {
             None
         } else {
+            #[allow(deprecated)] // try_update requires 1.95
             match self.channel.sender_count.fetch_update(
                 Ordering::Relaxed,
                 Ordering::Relaxed,
@@ -1029,6 +1030,7 @@ impl<T> WeakReceiver<T> {
         if self.channel.queue.is_closed() {
             None
         } else {
+            #[allow(deprecated)] // try_update requires 1.95
             match self.channel.receiver_count.fetch_update(
                 Ordering::Relaxed,
                 Ordering::Relaxed,


### PR DESCRIPTION
```
error: use of deprecated method `std::sync::atomic::Atomic::<usize>::fetch_update`: renamed to `try_update` for consistency
   --> src/lib.rs:986:45
    |
986 |             match self.channel.sender_count.fetch_update(
    |                                             ^^^^^^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(deprecated)]`
help: replace the use of the deprecated method
    |
986 -             match self.channel.sender_count.fetch_update(
986 +             match self.channel.sender_count.try_update(
    |

error: use of deprecated method `std::sync::atomic::Atomic::<usize>::fetch_update`: renamed to `try_update` for consistency
    --> src/lib.rs:1032:47
     |
1032 |             match self.channel.receiver_count.fetch_update(
     |                                               ^^^^^^^^^^^^
     |
help: replace the use of the deprecated method
     |
1032 -             match self.channel.receiver_count.fetch_update(
1032 +             match self.channel.receiver_count.try_update(
     |
```